### PR TITLE
Fix inconsistent indentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install
 Start the development server:
 
 ```bash
-    npm run dev
+npm run dev
 ```
 
 Open your browser and visit http://localhost:3000 to see the application running.


### PR DESCRIPTION
The indentation for the command `npm run dev` was inconsistent. This commit removes the indentation to align it with the formatting of the other commands.