### PR TITLE
Fix: Dropdown Menu

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -35,13 +35,13 @@ const AccountMenu = () => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem>
+        <DropdownMenuItem asChild>
           <Link href="/dashboard" className="flex gap-1 items-center">
             <Icons.settings className="mr-2 h-4 w-4" />
             <span>Dashboard</span>
           </Link>
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem asChild>
           <Link href="/profile" className="flex gap-1 items-center">
             <Icons.settings className="mr-2 h-4 w-4" />
             <span>Profile</span>


### PR DESCRIPTION
Profile dropdown menu will now close on click.

---
Bug Fix | Dropdown Menu
---

Discord Username: @sudo-adduser-jordan

## What type of PR is this? (select all that apply)

- [ x ] 🐛 Bug Fix

## Description

- Dropdown menu would stay open after navigating to new page.
- Dropdown menu will now close after navigating to a new page.

## QA Instructions, Screenshots, Recordings

1. Login.
2. Navigate to dashboard.
3. Navigate to profile.
4. Logout.

## Added/updated tests?

- [ x ] 🙅 no, because they aren't needed

