### PR TITLE
bugfix: Remove spinner in top right when loading pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NextTopLoader showSpinner={false}/>
+        <NextTopLoader showSpinner={false} />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Header />
           {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NextTopLoader />
+        <NextTopLoader showSpinner={false}/>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Header />
           {children}


### PR DESCRIPTION
---
title: BugFix: Remove spinner in top right when loading pages
---

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Noticed there's a spinner showing up on the top right corner when pages are loading.
This is part of the NextTopLoader.
Since NextTopLoader includes a loading progress bar, there's no need in an extra spinner, especially when it is misplaced. 

## QA Instructions, Screenshots, Recordings

Current state:
![image](https://github.com/webdevcody/code-racer/assets/18007338/d24a3d52-d8e1-4e3e-a6de-bd5e90b816da)

After changes: No spinner, only loading progress bar.

## Added/updated tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
