### PR TITLE
Fix: Result Table: accuracy Column Validation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model Result {
   id        String   @id @default(cuid())
   userId    String   @map("user_id")
   createdAt      DateTime @default(now()) @map("created_at")
-  accuracy  Decimal  @db.Decimal(3, 2)
+  accuracy  Decimal  @db.Decimal(5, 2)
   wpm       Int
   takenTime  String   @map("taken_time")
   errorCount Int?     @map("error_count")


### PR DESCRIPTION
---
Bug Fix |
---

Discord Username: @sudo-adduser-jordan 

## What type of PR is this? (select all that apply)

- [ x ] 🐛 Bug Fix

## Description

Previously  `Result Table: accuracy Column`  would only accept: `9.99`.
Now will accept: `100`, `99.99`.
Also fixes `saveUserResult()` error in `src\app\race\typingCode.tsx`.

## QA Instructions, Screenshots, Recordings

1. Login.
2. Navigate to Race Page.
3. Complete a race.
4. View Result Table in Prisma Stuido.
5. Optional: pass test values to `saveUserResult()` or `calculateAccuracy()`.

## Added/updated tests?

- [ x ] 🙅 no, because they aren't needed


## Additional Comments

Convert value once inserting into table. Opposed to converting value to display `100%` at each request. 