### PR TITLE
tooltip to show you can press esc

### DIFF
--- a/src/app/race/typingCode.tsx
+++ b/src/app/race/typingCode.tsx
@@ -9,6 +9,13 @@ import { useRouter } from "next/navigation";
 import RacePositionTracker from "./racePositionTracker";
 import { Snippet } from "@prisma/client";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 function calculateCPM(
   numberOfCharacters: number,
   secondsTaken: number
@@ -143,7 +150,16 @@ export default function TypingCode({ user, snippet }: TypingCodeProps) {
           <p className="mb-4">Errors: {errors.length}</p>
         </div>
       )}
-      <Button onClick={handleRestart}>Restart</Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button onClick={handleRestart}>Restart</Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Press Esc to reset quickly</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }


### PR DESCRIPTION
---
title: Issue #117  | tooltip to show you can press esc
---

Added a tooltip to show users esc button is available to press to reset.

Discord Username: @Buletins

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

### UI accessibility concerns?

## Added/updated tests?

- [x ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
