### PR TITLE
add a race column to recent races with a button to the same snippet

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ model VerificationToken {
 
 model Result {
   id         String   @id @default(cuid())
+  snippet    Snippet  @relation(fields: [snippetId], references: [id])
   userId     String   @map("user_id")
   createdAt  DateTime @default(now()) @map("created_at")
   accuracy   Decimal  @db.Decimal(5, 2)
@@ -73,6 +74,7 @@ model Result {
   takenTime  String   @map("taken_time")
   errorCount Int?     @map("error_count")
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  snippetId  String
 
   @@map("results")
 }
@@ -105,8 +107,9 @@ model Snippet {
 
   code     String
   language String
-  User     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId   String @map("user_id")
+  User     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId   String   @map("user_id")
+  Result   Result[]
 
   @@map("snippets")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,7 +66,7 @@ model VerificationToken {
 
 model Result {
   id         String   @id @default(cuid())
-  snippet    Snippet  @relation(fields: [snippetId], references: [id])
+  snippet    Snippet  @relation(fields: [snippetId], references: [id], onDelete: Cascade)
   userId     String   @map("user_id")
   createdAt  DateTime @default(now()) @map("created_at")
   accuracy   Decimal  @db.Decimal(5, 2)

--- a/src/app/dashboard/recent-races-table.tsx
+++ b/src/app/dashboard/recent-races-table.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import * as React from "react";
-import type { Result, User } from "@prisma/client";
+import type { Result } from "@prisma/client";
 
 import { type ColumnDef } from "unstyled-table";
-import Image from "next/image";
 import Link from "next/link";
 import { DataTable } from "@/components/data-table";
 import {
@@ -15,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Icons } from "@/components/icons";
 import { formatDate } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
 interface RecentRacesTableProps {
   data: Result[];
@@ -25,10 +25,31 @@ export function RecentRacesTable({ data, pageCount }: RecentRacesTableProps) {
   const columns = React.useMemo<ColumnDef<Result, unknown>[]>(
     () => [
       {
-        accessorKey: "id",
-        header: "Game id",
+        accessorKey: "snippetId",
+        header: "Race",
         enableSorting: false,
+        cell: ({ cell }) => {
+          const snippetId = cell.getValue() as string;
+          return (
+            <Link
+              className={buttonVariants({ variant: "default" })}
+              href={`/race?snippetId=${snippetId}`}
+            >
+              Re-race
+            </Link>
+          );
+        },
       },
+      {
+        accessorKey: "id",
+        header: "Result Id",
+        enableSorting: false,
+        cell: ({ cell }) => {
+          const id = cell.getValue() as string;
+          return id.slice(0, 4) + "..." + id.slice(id.length - 4);
+        },
+      },
+
       {
         accessorKey: "errorCount",
         header: "Errors",

--- a/src/app/race/actions.ts
+++ b/src/app/race/actions.ts
@@ -1,18 +1,23 @@
 "use server";
 
-import { Result } from "@prisma/client";
+import { User, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
-type NewResult = Omit<Result, "id" | "createdAt">;
-
-export async function saveUserResultAction(input: NewResult) {
+export async function saveUserResultAction(input: {
+  userId: User["id"];
+  timeTaken: string | number;
+  errors: number;
+  cpm: number;
+  accuracy: number;
+  snippetId: string;
+}) {
   await prisma.result.create({
     data: {
       userId: input.userId,
-      takenTime: input.takenTime,
-      errorCount: input.errorCount,
+      takenTime: input.timeTaken.toString(),
+      errorCount: input.errors,
       cpm: input.cpm,
-      accuracy: input.accuracy,
+      accuracy: new Prisma.Decimal(input.accuracy),
       snippetId: input.snippetId,
     },
   });

--- a/src/app/race/actions.ts
+++ b/src/app/race/actions.ts
@@ -9,6 +9,7 @@ export async function saveUserResultAction(input: {
   errors: number;
   cpm: number;
   accuracy: number;
+  snippetId: string;
 }) {
   await prisma.result.create({
     data: {
@@ -17,6 +18,7 @@ export async function saveUserResultAction(input: {
       errorCount: input.errors,
       cpm: input.cpm,
       accuracy: new Prisma.Decimal(input.accuracy),
+      snippetId: input.snippetId,
     },
   });
 }

--- a/src/app/race/actions.ts
+++ b/src/app/race/actions.ts
@@ -1,23 +1,18 @@
 "use server";
 
-import { User, Prisma } from "@prisma/client";
+import { Result } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
-export async function saveUserResultAction(input: {
-  userId: User["id"];
-  timeTaken: string | number;
-  errors: number;
-  cpm: number;
-  accuracy: number;
-  snippetId: string;
-}) {
+type NewResult = Omit<Result, "id" | "createdAt">;
+
+export async function saveUserResultAction(input: NewResult) {
   await prisma.result.create({
     data: {
       userId: input.userId,
-      takenTime: input.timeTaken.toString(),
-      errorCount: input.errors,
+      takenTime: input.takenTime,
+      errorCount: input.errorCount,
       cpm: input.cpm,
-      accuracy: new Prisma.Decimal(input.accuracy),
+      accuracy: input.accuracy,
       snippetId: input.snippetId,
     },
   });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -15,9 +15,28 @@ async function getRandomSnippet() {
     .then((results) => (results.length > 0 ? results[0] : undefined));
 }
 
-export default async function Race() {
+async function getSearchParamSnippet(snippetId: string | string[]) {
+  if (typeof snippetId === "string") {
+    return await prisma.snippet.findFirst({
+      where: {
+        id: snippetId,
+      },
+    });
+  }
+  return null;
+}
+
+export default async function Race({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[]>;
+}) {
   const user = await getCurrentUser();
-  const snippet = await getRandomSnippet();
+  const snippet =
+    (await getSearchParamSnippet(searchParams.snippetId)) ??
+    (await getRandomSnippet());
+
+  console.log(snippet);
 
   return (
     <main className="flex md:min-h-[calc(100vh-11rem)] flex-col items-center justify-between p-24">

--- a/src/app/race/typingCode.tsx
+++ b/src/app/race/typingCode.tsx
@@ -52,6 +52,7 @@ export default function TypingCode({ user, snippet }: TypingCodeProps) {
           errors: errors.length,
           cpm: calculateCPM(code.length, timeTaken),
           accuracy: calculateAccuracy(code.length, errors.length),
+          snippetId: snippet.id,
         });
     }
     if (inputEl.current !== null) {

--- a/src/app/race/typingCode.tsx
+++ b/src/app/race/typingCode.tsx
@@ -8,7 +8,6 @@ import { saveUserResultAction } from "./actions";
 import { useRouter } from "next/navigation";
 import RacePositionTracker from "./racePositionTracker";
 import { Snippet } from "@prisma/client";
-import { Decimal } from "@prisma/client/runtime";
 
 function calculateCPM(
   numberOfCharacters: number,
@@ -18,7 +17,10 @@ function calculateCPM(
   return Math.round(numberOfCharacters / minutesTaken);
 }
 
-function calculateAccuracy(numberOfCharacters: number, errorsCount: number) {
+function calculateAccuracy(
+  numberOfCharacters: number,
+  errorsCount: number,
+): number {
   return 1 - errorsCount / numberOfCharacters;
 }
 
@@ -40,16 +42,16 @@ export default function TypingCode({ user, snippet }: TypingCodeProps) {
 
   useEffect(() => {
     if (startTime && endTime) {
-      const takenTime: number =
+      const timeTaken: number =
         (endTime.getTime() - startTime.getTime()) / 1000;
 
       if (user)
         saveUserResultAction({
           userId: user.id,
-          takenTime: takenTime.toString(),
-          errorCount: errors.length,
-          cpm: calculateCPM(code.length, takenTime),
-          accuracy: new Decimal(calculateAccuracy(code.length, errors.length)),
+          timeTaken,
+          errors: errors.length,
+          cpm: calculateCPM(code.length, timeTaken),
+          accuracy: calculateAccuracy(code.length, errors.length),
           snippetId: snippet.id,
         });
     }
@@ -58,16 +60,7 @@ export default function TypingCode({ user, snippet }: TypingCodeProps) {
     }
 
     if (isEnd && endTime && startTime) router.push("/result");
-  }, [
-    endTime,
-    startTime,
-    user,
-    errors.length,
-    isEnd,
-    router,
-    code.length,
-    snippet.id,
-  ]);
+  }, [endTime, startTime, user, errors.length, isEnd, router, code.length]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInput(event.target.value);


### PR DESCRIPTION
---
title: Issue #130 | add a column to recent races table on dashboard that takes you to a race with the same snippet 
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @_mshub

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- added a new relation between a Snippet and a Result
- races page first checks searchParams for snippetId, if not found finds a random snippet
- added a new column to recent races table on the dashboard that displays a button to retry the same snippet

## Related Tickets & Documents

- Related Issue #130 
- Closes #130 

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->
- added a new column to recent races table on the dashboard

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->
- no

## Added/updated tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
