### PR TITLE
added toast for successful name update

### DIFF
--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -6,8 +6,10 @@ import React from "react";
 import { Input } from "./input";
 import { Button } from "./button";
 import { cn, throwError } from "@/lib/utils";
+import { useToast } from "./use-toast";
 
-export interface EditableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface EditableInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** How would you like to save the text? */
   actionOnSave: () => Promise<void>;
 }
@@ -22,6 +24,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
     const [edit, setEdit] = React.useState(false);
     const [newValue, setNewValue] = React.useState(value);
     const divRef = React.useRef<HTMLDivElement>(null);
+    const { toast } = useToast();
 
     React.useEffect(() => {
       const onClickEdit = () => setEdit(true);
@@ -80,6 +83,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                   }
                   setEdit(false);
                   await actionOnSave();
+                  toast({
+                    title: "Username successfully updated.",
+                    description: "Your username has been successfully updated.",
+                    variant: "default",
+                  });
                 }}
               >
                 Save


### PR DESCRIPTION
---
title: Issue #156  | I added a toast for when the user updates the username. 
---

Discord Username: @trace2798 

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature

## Description

 I added a toast for when the user updates the username. It has the title "Username successfully updated.". Description: "Your username has been successfully updated." and a  Variant: "default",

## Related Tickets & Documents

- Related Issue #156 
- Closes #156 

## QA Instructions, Screenshots, Recordings

Previously once a user updates their username it gets updated but there was not any form of notification. Now after the introduction of the toast, a toast should pop up when the user successfully updates their name.

## Added/updated tests?

- [ ] 🙅 no, because they aren't needed
