### PR TITLE
Toast empty string update name

### DIFF
--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -80,6 +80,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                 onClick={async () => {
                   if (!newValue) {
                     throwError(new Error("Empty strings are not allowed!"));
+                    toast({
+                      title: "Username cannot be an empty string.",
+                      description: "Your username cannot be an empty string.",
+                      variant: "destructive",
+                    });
                   }
                   setEdit(false);
                   await actionOnSave();

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -6,8 +6,10 @@ import React from "react";
 import { Input } from "./input";
 import { Button } from "./button";
 import { cn, throwError } from "@/lib/utils";
+import { useToast } from "./use-toast";
 
-export interface EditableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface EditableInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** How would you like to save the text? */
   actionOnSave: () => Promise<void>;
 }
@@ -22,6 +24,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
     const [edit, setEdit] = React.useState(false);
     const [newValue, setNewValue] = React.useState(value);
     const divRef = React.useRef<HTMLDivElement>(null);
+    const { toast } = useToast();
 
     React.useEffect(() => {
       const onClickEdit = () => setEdit(true);
@@ -80,6 +83,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                   }
                   setEdit(false);
                   await actionOnSave();
+                  toast({
+                    title: "Username successfully updated.",
+                    description: "Your username has been successfully updated.",
+                    variant: "default",
+                  });
                 }}
               >
                 Save


### PR DESCRIPTION
---
title: Issue #158  | Toast when updated username is empty string,
---

Discord Username: @trace2798 

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature

## Description

Added a toast for when the updated username is an empty string. It has a title: "Username cannot be an empty string." Description: "Your username cannot be an empty string." Variant: "destructive",

## Related Tickets & Documents

- Related Issue #158
- Closes #158

## QA Instructions, Screenshots, Recordings

Previously once you update the username and put nothing nothing happens. After the introduction of the toast, a red toast should pop up when the user tries to submit an empty string.

## Added/updated tests?

- [ ] 🙅 no, because they aren't needed
