### PR TITLE
Toast for updated name same as initial

### DIFF
--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -80,6 +80,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                 onClick={async () => {
                   if (!newValue) {
                     throwError(new Error("Empty strings are not allowed!"));
+                    toast({
+                      title: "Username cannot be an empty string.",
+                      description: "Your username cannot be an empty string.",
+                      variant: "destructive",
+                    });
                   }
                   setEdit(false);
                   await actionOnSave();

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -6,8 +6,10 @@ import React from "react";
 import { Input } from "./input";
 import { Button } from "./button";
 import { cn, throwError } from "@/lib/utils";
+import { useToast } from "./use-toast";
 
-export interface EditableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface EditableInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** How would you like to save the text? */
   actionOnSave: () => Promise<void>;
 }
@@ -22,6 +24,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
     const [edit, setEdit] = React.useState(false);
     const [newValue, setNewValue] = React.useState(value);
     const divRef = React.useRef<HTMLDivElement>(null);
+    const { toast } = useToast();
 
     React.useEffect(() => {
       const onClickEdit = () => setEdit(true);
@@ -80,6 +83,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                   }
                   setEdit(false);
                   await actionOnSave();
+                  toast({
+                    title: "Username successfully updated.",
+                    description: "Your username has been successfully updated.",
+                    variant: "default",
+                  });
                 }}
               >
                 Save

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -86,6 +86,15 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                       variant: "destructive",
                     });
                   }
+                  if (newValue === value) {
+                    throwError(new Error("name-is-the-same"));
+                    toast({
+                      title: "Same username as before.",
+                      description:
+                        "Oops look like your username is same as it was.",
+                      variant: "middle",
+                    });
+                  }
                   setEdit(false);
                   await actionOnSave();
                   toast({

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import * as ToastPrimitives from "@radix-ui/react-toast"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const ToastProvider = ToastPrimitives.Provider
+const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
@@ -15,12 +15,12 @@ const ToastViewport = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className
+      className,
     )}
     {...props}
   />
-))
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
   "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
@@ -30,13 +30,14 @@ const toastVariants = cva(
         default: "border bg-background",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
+        middle: "border bg-indigo-500 text-destructive-foreground",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
@@ -49,9 +50,9 @@ const Toast = React.forwardRef<
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
-  )
-})
-Toast.displayName = ToastPrimitives.Root.displayName
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
@@ -61,12 +62,12 @@ const ToastAction = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
-      className
+      className,
     )}
     {...props}
   />
-))
-ToastAction.displayName = ToastPrimitives.Action.displayName
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
@@ -76,15 +77,15 @@ const ToastClose = React.forwardRef<
     ref={ref}
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
-      className
+      className,
     )}
     toast-close=""
     {...props}
   >
     <X className="h-4 w-4" />
   </ToastPrimitives.Close>
-))
-ToastClose.displayName = ToastPrimitives.Close.displayName
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
@@ -95,8 +96,8 @@ const ToastTitle = React.forwardRef<
     className={cn("text-sm font-semibold", className)}
     {...props}
   />
-))
-ToastTitle.displayName = ToastPrimitives.Title.displayName
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
@@ -107,12 +108,12 @@ const ToastDescription = React.forwardRef<
     className={cn("text-sm opacity-90", className)}
     {...props}
   />
-))
-ToastDescription.displayName = ToastPrimitives.Description.displayName
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,
@@ -124,4 +125,4 @@ export {
   ToastDescription,
   ToastClose,
   ToastAction,
-}
+};


### PR DESCRIPTION
---
title: Issue #162  | Added check and toast
---

Discord Username: @trace2798 

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature

## Description

I believe this will provide a better user experience. I added a check to check if newValue === initial value. If it is true a toast will pop up which is using the custom "middle" variant. The toast has title: "Same username as before.", description: "Oops look like your username is same as it was.", and variant: "middle".

## Related Tickets & Documents

- Related Issue #162 
- Closes #162 

## QA Instructions, Screenshots, Recordings

To check you can go to profile --> editable input field --> Just click save without changing anything. A blue toast with the title, description as mentioned above should pop up.

## Added/updated tests?

- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
