### PR TITLE
Consistent layout

### DIFF
--- a/src/app/add-snippet/page.tsx
+++ b/src/app/add-snippet/page.tsx
@@ -1,11 +1,16 @@
 "use client";
+import { Heading } from "@/components/ui/heading";
 import AddSnippetForm from "./_components/add-snippet-form";
 
 export default function AddSnippet() {
   return (
     <div className="min-h-screen py-24 ">
       <section className="max-w-xl mx-auto ">
-        <h2 className="text-4xl font-bold">Add Your Snippet</h2>
+        {/* <h2 className="text-4xl font-bold">Add Your Snippet</h2> */}
+        <Heading
+        title="Add Your Snippet"
+        description="Add Your Snippet to get started"
+      />
         <AddSnippetForm />
       </section>
     </div>

--- a/src/app/add-snippet/page.tsx
+++ b/src/app/add-snippet/page.tsx
@@ -4,13 +4,13 @@ import AddSnippetForm from "./_components/add-snippet-form";
 
 export default function AddSnippet() {
   return (
-    <div className="min-h-screen py-24 ">
-      <section className="max-w-xl mx-auto ">
+    <div className="py-16">
+      <section className="max-w-xl mx-auto">
         {/* <h2 className="text-4xl font-bold">Add Your Snippet</h2> */}
         <Heading
-        title="Add Your Snippet"
-        description="Add Your Snippet to get started"
-      />
+          title="Add Your Snippet"
+          description="Add Your Snippet to get started"
+        />
         <AddSnippetForm />
       </section>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
         <NextTopLoader showSpinner={false} />
         <ContextProvider>
           <Header />
-          {children}
+          <div className="container h-fit py-2 md:py-24">{children}</div>
           <Footer />
           <Toaster />
           <TailwindIndicator />

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -54,12 +54,9 @@ export default async function LeaderboardPage({
   const pageCount = totalResults === 0 ? 1 : Math.ceil(totalResults / take);
 
   return (
-    <div className="container md:min-h-[calc(100vh-12rem)] max-w-4xl mt-2">
+    <div>
       {/* <h1 className="my-4 text-3xl text-foreground">Leaderboard.</h1> */}
-      <Heading
-        title="Leaderboard"
-        description="Find your competition"
-      />
+      <Heading title="Leaderboard" description="Find your competition" />
       <ResultsTable data={results} pageCount={pageCount} />
     </div>
   );

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { prisma } from "@/lib/prisma";
 import { ResultsTable } from "./results-table";
 import { Result } from "@prisma/client";
+import { Heading } from "@/components/ui/heading";
 
 interface LeaderboardPageProps {
   searchParams: {
@@ -53,8 +54,12 @@ export default async function LeaderboardPage({
   const pageCount = totalResults === 0 ? 1 : Math.ceil(totalResults / take);
 
   return (
-    <div className="container md:min-h-[calc(100vh-12rem)] max-w-4xl">
-      <h1 className="my-4 text-3xl text-foreground">Leaderboard.</h1>
+    <div className="container md:min-h-[calc(100vh-12rem)] max-w-4xl mt-2">
+      {/* <h1 className="my-4 text-3xl text-foreground">Leaderboard.</h1> */}
+      <Heading
+        title="Leaderboard"
+        description="Find your competition"
+      />
       <ResultsTable data={results} pageCount={pageCount} />
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,10 +3,13 @@ import BannerSvg from "./bannerSvg";
 
 export default async function Home() {
   return (
-    <main className="container py-24">
+    <main>
       <div className="flex flex-col md:flex-row justify-between items-center">
         <HeroBanner />
-        <BannerSvg gearRightClass={"origin-[50%_50%] animate-gear-rotate-left"} gearLeftClass={"origin-[50%_50%] animate-gear-rotate-right"}/>
+        <BannerSvg
+          gearRightClass={"origin-[50%_50%] animate-gear-rotate-left"}
+          gearLeftClass={"origin-[50%_50%] animate-gear-rotate-right"}
+        />
       </div>
     </main>
   );

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -80,6 +80,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                 onClick={async () => {
                   if (!newValue) {
                     throwError(new Error("Empty strings are not allowed!"));
+                    toast({
+                      title: "Username cannot be an empty string.",
+                      description: "Your username cannot be an empty string.",
+                      variant: "destructive",
+                    });
                   }
                   setEdit(false);
                   await actionOnSave();

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -6,8 +6,10 @@ import React from "react";
 import { Input } from "./input";
 import { Button } from "./button";
 import { cn, throwError } from "@/lib/utils";
+import { useToast } from "./use-toast";
 
-export interface EditableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface EditableInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** How would you like to save the text? */
   actionOnSave: () => Promise<void>;
 }
@@ -22,6 +24,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
     const [edit, setEdit] = React.useState(false);
     const [newValue, setNewValue] = React.useState(value);
     const divRef = React.useRef<HTMLDivElement>(null);
+    const { toast } = useToast();
 
     React.useEffect(() => {
       const onClickEdit = () => setEdit(true);
@@ -80,6 +83,11 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                   }
                   setEdit(false);
                   await actionOnSave();
+                  toast({
+                    title: "Username successfully updated.",
+                    description: "Your username has been successfully updated.",
+                    variant: "default",
+                  });
                 }}
               >
                 Save

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -61,7 +61,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
               autoFocus
               {...props}
             />
-            <div className="absolute top-0 right-0 flex items-center justify-center w-24 h-full gap-2 bg-background">
+            <div className="absolute top-11 right-0 flex items-center w-full justify-evenly h-full gap-2 bg-background">
               <button
                 type="button"
                 className="relative w-4 h-4"

--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -86,6 +86,15 @@ const EditableInput = React.forwardRef<HTMLInputElement, EditableInputProps>(
                       variant: "destructive",
                     });
                   }
+                  if (newValue === value) {
+                    throwError(new Error("name-is-the-same"));
+                    toast({
+                      title: "Same username as before.",
+                      description:
+                        "Oops look like your username is same as it was.",
+                      variant: "middle",
+                    });
+                  }
                   setEdit(false);
                   await actionOnSave();
                   toast({

--- a/src/components/ui/heading.tsx
+++ b/src/components/ui/heading.tsx
@@ -1,0 +1,13 @@
+interface HeadingProps {
+  title: string;
+  description: string;
+}
+
+export const Heading: React.FC<HeadingProps> = ({ title, description }) => {
+  return (
+    <div>
+      <h2 className="text-2xl md:text-4xl font-bold tracking-tight">{title}</h2>
+      <p className="text-sm md:text-base text-muted-foreground">{description}</p>
+    </div>
+  );
+};

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import * as ToastPrimitives from "@radix-ui/react-toast"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const ToastProvider = ToastPrimitives.Provider
+const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
@@ -15,12 +15,12 @@ const ToastViewport = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className
+      className,
     )}
     {...props}
   />
-))
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
   "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
@@ -30,13 +30,14 @@ const toastVariants = cva(
         default: "border bg-background",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
+        middle: "border bg-indigo-500 text-destructive-foreground",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
@@ -49,9 +50,9 @@ const Toast = React.forwardRef<
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
-  )
-})
-Toast.displayName = ToastPrimitives.Root.displayName
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
@@ -61,12 +62,12 @@ const ToastAction = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
-      className
+      className,
     )}
     {...props}
   />
-))
-ToastAction.displayName = ToastPrimitives.Action.displayName
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
@@ -76,15 +77,15 @@ const ToastClose = React.forwardRef<
     ref={ref}
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
-      className
+      className,
     )}
     toast-close=""
     {...props}
   >
     <X className="h-4 w-4" />
   </ToastPrimitives.Close>
-))
-ToastClose.displayName = ToastPrimitives.Close.displayName
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
@@ -95,8 +96,8 @@ const ToastTitle = React.forwardRef<
     className={cn("text-sm font-semibold", className)}
     {...props}
   />
-))
-ToastTitle.displayName = ToastPrimitives.Title.displayName
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
@@ -107,12 +108,12 @@ const ToastDescription = React.forwardRef<
     className={cn("text-sm opacity-90", className)}
     {...props}
   />
-))
-ToastDescription.displayName = ToastPrimitives.Description.displayName
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,
@@ -124,4 +125,4 @@ export {
   ToastDescription,
   ToastClose,
   ToastAction,
-}
+};


### PR DESCRIPTION
---
title: Issue #173  | Added classes for consistent layout for the whole application.
---


Discord Username: @trace2798 

## What type of PR is this? (select all that apply)

- [ ] 🐛 Bug Fix

## Description

As mentioned in the bug, "The home page has the following property for the overall layout container and py-24. Leadership page has the following: container md:min-h-[calc(100vh-12rem)] max-w-4xl and the add snippet page has the following: min-h-screen and py-24.
From UI/UX perspective it is better to follow a consistent pattern."

Changes: Added a div to wrap children in the main layout.tsx with the following properties "container h-fit py-2 md:py-24" made the py-24 from the medium screen since home page was not looking good on mobile view with that padding. 

On the main page.tsx removed the class name from the <main>
On page.tsx of leaderboard removed class name from the main div
On page.tsx of add-snippet removed the existing class name and just added py-16 to make the Add snippet container align center (iPhone X)

## Related Tickets & Documents

- Related Issue #173 
- Closes #173 

## QA Instructions, Screenshots, Recordings

N/A

### UI accessibility concerns?

Not sure what to answer here, 

## Added/updated tests?

- [ ] 🙅 no, because they aren't needed.

I do not know if I will need to update or add any. 
