### PR TITLE
#184 Cancel name editing on Escape key press

### DIFF
--- a/src/components/ui/editable-input.tsx
+++ b/src/components/ui/editable-input.tsx
@@ -44,6 +44,7 @@ const EditableInput = React.forwardRef<HTMLInputElement, React.InputHTMLAttribut
               type={type}
               value={newValue}
               onChange={(e) => setNewValue(e.target.value)}
+              onKeyDown={(e) => e.key === "Escape" && setEdit(false)}
               placeholder="Please provide a value!"
               ref={ref}
               className={cn(


### PR DESCRIPTION
---
title: Issue # 184 | [FEAT]: Cancel name editing on Esc key press
---

<!-- Please ensure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @_salyut

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
I have added profile name editing cancellation on "Escape" key press.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #184 
- Closes #184 

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
