### PR TITLE
added link to race route on toast

### DIFF
--- a/src/app/add-snippet/_components/add-snippet-form.tsx
+++ b/src/app/add-snippet/_components/add-snippet-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import React, { useState } from "react";
 import { addSnippetAction } from "../actions";
 import { toast } from "@/components/ui/use-toast";
@@ -11,6 +11,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { ToastAction } from "@/components/ui/toast";
 import { CheckCircledIcon, CrossCircledIcon } from "@radix-ui/react-icons";
 import { CheckIcon } from "lucide-react";
+import Link from "next/link";
 
 export default function AddSnippetForm({}) {
   const [codeSnippet, setCodeSnippet] = useState("");
@@ -44,8 +45,7 @@ export default function AddSnippetForm({}) {
       await addSnippetAction({
         language: codeLanguage,
         code: codeSnippet,
-      })
-      .then((res) => {
+      }).then((res) => {
         if (res?.message === "snippet-created-and-achievement-unlocked") {
           toast({
             title: "Achievement Unlocked",
@@ -76,15 +76,12 @@ export default function AddSnippetForm({}) {
     toast({
       title: "Success!",
       description: "Snippet added successfully",
-      duration: 3000,
-      style: {
-        background: "#A2FF86",
-        color: "#213363",
-      },
+      duration: 5000,
+      variant: "middle",
       action: (
-        <ToastAction altText="error">
-          <CheckIcon width={32} height={32} />
-        </ToastAction>
+        <Link href="/race" className={buttonVariants({ variant: "outline" })}>
+          Click to Race
+        </Link>
       ),
     });
 


### PR DESCRIPTION
---
title: Issue #205  | Added link to race route on toast.
---

Discord Username: @trace2798 

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Now once a user uploads a toast he/she/they can directly go to race page if he/she/they click on the 'Click to Race' button

## Related Tickets & Documents

- Related Issue #205 
- Closes #205 

## QA Instructions, Screenshots, Recordings

Before: https://imgur.com/fegFItU
After: https://imgur.com/n8rQrzj

### UI accessibility concerns?
 Unsure

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
