### PR TITLE
[322] bug: focus race input on load

### DIFF
--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -90,7 +90,6 @@ export default function Race({ user, snippet }: RaceProps) {
       }
     };
     document.addEventListener("keydown", handleRestartKey);
-    focusOnLoad();
     return () => {
       document.removeEventListener("keydown", handleRestartKey);
     };
@@ -201,6 +200,7 @@ export default function Race({ user, snippet }: RaceProps) {
         <input
           type="text"
           // value={input}
+          autoFocus
           defaultValue={input}
           ref={inputElement}
           onKeyDown={handleKeyboardEvent}

--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -90,6 +90,7 @@ export default function Race({ user, snippet }: RaceProps) {
       }
     };
     document.addEventListener("keydown", handleRestartKey);
+    focusOnLoad();
     return () => {
       document.removeEventListener("keydown", handleRestartKey);
     };
@@ -181,7 +182,7 @@ export default function Race({ user, snippet }: RaceProps) {
   return (
     <>
       <div
-        className="w-3/4 lg:p-8 p-4 bg-accent rounded-md relative flex flex-col gap-2"
+        className="relative flex flex-col w-3/4 gap-2 p-4 rounded-md lg:p-8 bg-accent"
         onClick={focusOnLoad}
         role="none" // eslint fix - will remove the semantic meaning of an element while still exposing it to assistive technology
       >
@@ -204,7 +205,7 @@ export default function Race({ user, snippet }: RaceProps) {
           ref={inputElement}
           onKeyDown={handleKeyboardEvent}
           disabled={isRaceFinished}
-          className="w-full h-full absolute p-8 inset-y-0 left-0 -z-40 focus:outline outline-blue-500 rounded-md"
+          className="absolute inset-y-0 left-0 w-full h-full p-8 rounded-md -z-40 focus:outline outline-blue-500"
           onPaste={(e) => e.preventDefault()}
         />
         <div className="self-start">

--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -90,7 +90,6 @@ export default function Race({ user, snippet }: RaceProps) {
       }
     };
     document.addEventListener("keydown", handleRestartKey);
-    focusOnLoad();
     return () => {
       document.removeEventListener("keydown", handleRestartKey);
     };
@@ -201,6 +200,8 @@ export default function Race({ user, snippet }: RaceProps) {
         <input
           type="text"
           // value={input}
+          // eslint-disable-next-line
+          autoFocus
           defaultValue={input}
           ref={inputElement}
           onKeyDown={handleKeyboardEvent}

--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -90,6 +90,7 @@ export default function Race({ user, snippet }: RaceProps) {
       }
     };
     document.addEventListener("keydown", handleRestartKey);
+    focusOnLoad();
     return () => {
       document.removeEventListener("keydown", handleRestartKey);
     };
@@ -200,7 +201,6 @@ export default function Race({ user, snippet }: RaceProps) {
         <input
           type="text"
           // value={input}
-          autoFocus
           defaultValue={input}
           ref={inputElement}
           onKeyDown={handleKeyboardEvent}


### PR DESCRIPTION
---
Issue #322 | Focus race input on first load: Issue
---

Discord Username: @spaghetti#8809

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

It now focuses on the race input right after user enters the racing page.

## QA Instructions, Screenshots, Recordings
![изображение](https://github.com/webdevcody/code-racer/assets/67381256/0e8016a8-1ba8-4544-a00e-f22dcb5e38ff)

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
