### PR TITLE
Move timer to avoid text shifting

### DIFF
--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -434,7 +434,8 @@ export default function Race({
           onPaste={(e) => e.preventDefault()}
         />
 
-        <div className="flex justify-between">
+        <div className="flex justify-between items-center">
+          {showRaceTimer && <RaceTimer />}
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -447,7 +448,6 @@ export default function Race({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          {showRaceTimer && <RaceTimer />}
         </div>
       </div>
 

--- a/src/app/race/race.tsx
+++ b/src/app/race/race.tsx
@@ -435,19 +435,23 @@ export default function Race({
         />
 
         <div className="flex justify-between items-center">
-          {showRaceTimer && <RaceTimer />}
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" onClick={handleRestart}>
-                  Restart (ESC)
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Press Esc to reset</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          {showRaceTimer && (
+            <>
+              <RaceTimer />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="outline" onClick={handleRestart}>
+                      Restart (ESC)
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Press Esc to reset</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
---
No Issue # | Move timer to avoid text shifting
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @xdguido

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Playing around with the racer I noticed the timer shifts a lot when time passes. I founded it distracting and leverage that to make my first PR.
The PR involves just a change of position with the Reset button and add an 'item-center' to the container. In the future it could be improved to avoid shifting in the 'seconds' marker. 
I also hide the restart button when it is not racing.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
