### PR TITLE
[327] fix: fetch return 401 in GitHubCommitDisplay component

### DIFF
--- a/src/app/contributors/_components/github-commit-display.tsx
+++ b/src/app/contributors/_components/github-commit-display.tsx
@@ -29,9 +29,6 @@ async function getContributorCommitList(
       next: {
         revalidate: siteConfig.api.github.cacheRevalidationInterval,
       },
-      headers: {
-        Authorization: "Bearer " + siteConfig.api.github.accessToken,
-      },
     });
     if (!response.ok) {
       throw new Error("Fetch failed" + url);

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -45,7 +45,7 @@ export const siteConfig = {
       githubContributorActivity:
         "https://api.github.com/repos/webdevcody/code-racer/stats/contributors",
       githubListCommit: "https://api.github.com/repos/webdevcody/code-racer/commits",
-      cacheRevalidationInterval: 60 * 60,
+      cacheRevalidationInterval: 86400, // 24hrs
     },
   },
 };


### PR DESCRIPTION
---
title: Issue #327 | Quick bug fix: fetch return 401 in GitHubCommitDisplay component
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @phoukiethseng 

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Since we didn't have access token yet, fetch will return status 401 bad authorization request

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #327
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
