### PR TITLE
#442 | [BUG]: Link to user profile on leaderboard not updated & biography cannot be empty

### DIFF
--- a/src/app/leaderboard/users-table.tsx
+++ b/src/app/leaderboard/users-table.tsx
@@ -40,7 +40,7 @@ export function UsersTable({
           const userInfo = cell.getValue() as User;
 
           return (
-            <Link href={`${userInfo.id}`}>
+            <Link href={`/users/${userInfo.id}`}>
               <div className="flex items-center gap-2">
                 <Image
                   className="rounded-full"

--- a/src/app/users/(user-profile)/(components)/actions.ts
+++ b/src/app/users/(user-profile)/(components)/actions.ts
@@ -26,12 +26,16 @@ export const updateUserProfile = action(
   async (input, { user, prisma }) => {
     if (!user) throw new UnauthorizedError();
 
-    if (input.biography) {
-      const bioSchema = z
-        .string()
-        .max(128)
-        .refine((bio) => bio.trim());
+    if (input.biography || input.biography === "") {
+      const bioSchema =
+        input.biography.length > 128
+          ? z
+              .string()
+              .max(128)
+              .refine((bio) => bio.trim())
+          : z.string();
       const parsedBio = await bioSchema.parseAsync(input.biography);
+
       await prisma.user.update({
         where: {
           id: user.id,

--- a/src/app/users/(user-profile)/(components)/profile-card.tsx
+++ b/src/app/users/(user-profile)/(components)/profile-card.tsx
@@ -111,6 +111,7 @@ function EditMode({
     );
 
     try {
+      console.log(biography);
       await updateUserProfile({
         displayName: name,
         biography: biography as string,

--- a/src/app/users/(user-profile)/(components)/profile-card.tsx
+++ b/src/app/users/(user-profile)/(components)/profile-card.tsx
@@ -111,7 +111,6 @@ function EditMode({
     );
 
     try {
-      console.log(biography);
       await updateUserProfile({
         displayName: name,
         biography: biography as string,


### PR DESCRIPTION
---
#442 | [BUG]: Link to user profile on leaderboard not updated & biography cannot be empty
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @aaronragudos

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

A mistake was made by me so a bug occured in the if statement of the action, updateUserProfile, since it said that if (input.biography) exists, that is when we should only update the biography, however, that condition is returned as false if the biography becomes an empty string, so I fixed it. That conditional was there to prevent us to update the biography even though it's not provided as a parameter.

Next bug was that the href in a table row in leaderboard page was not updated to /users/${user.id}, so I updated them.

## Related Tickets & Documents

- Related Issue #442
- Closes #442 

## QA Instructions, Screenshots, Recordings

Video is in issue #442 

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
