### PR TITLE
fix mobile nav active item text color on light theme, extra space in footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -24,7 +24,7 @@ export function Footer() {
             >
               Cody
             </Link>
-            &nbsp; & his{" "}
+            &nbsp;& his{" "}
             <Link
               href={siteConfig.links.codyDiscord}
               target="_blank"

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -49,10 +49,8 @@ export function MobileNav({
                       buttonVariants({ size: "lg" }),
                       "text-xl w-full",
                       {
-                        "bg-background border-2 border-primary": isActiveRoute(
-                          currentPathName,
-                          item.href,
-                        ),
+                        "bg-background border-2 border-primary text-primary":
+                          isActiveRoute(currentPathName, item.href),
                       },
                     )}
                     href={item.href}


### PR DESCRIPTION
---
title: No Issue # | fix mobile nav active item text color on light theme, extra space in footer
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @_mshub

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
