### PR TITLE
Fixed dropdown bug

### DIFF
--- a/src/app/add-snippet/_components/language-dropdown.tsx
+++ b/src/app/add-snippet/_components/language-dropdown.tsx
@@ -29,7 +29,8 @@ const LanguageDropDown = ({
   className?: string;
 }) => {
   const [open, setOpen] = React.useState(false);
-
+  const [search, setSearch] = React.useState('');
+   
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -49,19 +50,23 @@ const LanguageDropDown = ({
       </PopoverTrigger>
       <PopoverContent className="w-full p-0 h-44">
         <Command>
-          <CommandInput placeholder="Search a Language..." />
+          <CommandInput placeholder="Search a Language..." value = {search} onValueChange={setSearch}/>
           <CommandEmpty>No language found.</CommandEmpty>
           <CommandGroup className="overflow-y-auto">
-            {snippetLanguages.map((language) => (
-              <CommandItem
-                key={language.value}
-                onSelect={(currentValue) => {
-                  setCodeLanguage(
-                    currentValue === codeLanguage ? "" : currentValue,
-                  );
-                  setOpen(false);
-                }}
-              >
+          {snippetLanguages
+          .filter(language => 
+          language.label.toLowerCase().includes(search.toLowerCase()))
+          .map((language) => (
+          <CommandItem
+            key={language.label}
+            value={language.value}
+            onSelect={(currentValue) => {
+              setCodeLanguage(
+                currentValue === codeLanguage ? "" : currentValue,
+              );
+              setOpen(false);
+            }}
+          >
                 <Check
                   className={cn(
                     "mr-2 h-4 w-4",


### PR DESCRIPTION
---
title: Issue # 448 | Issue with language select typeahead on race selection page
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @ysl0212

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Fixed the bug when user go to language select dropdown, the result is not showing correctly.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Go to the language select dropdown.
type "tx"
notice you get no results
backspace the "x"
type "y"
Now it should show the result correctly

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
