### PR TITLE
[475]: Display Current User's Overall Rankings on Leaderboard Page

### DIFF
--- a/packages/app/cypress/e2e/src/app/leaderboard/page.cy.ts
+++ b/packages/app/cypress/e2e/src/app/leaderboard/page.cy.ts
@@ -1,0 +1,10 @@
+describe("Leaderboard Page", () => {
+  it("should not display the the rankings when user is not signed in", () => {
+    cy.visit(`http://localhost:${process.env.PORT ?? 3000}/leaderboard`);
+    cy.get("body")
+      .should("not.contain.text", "Your Rankings")
+      .should("not.contain.text", "BY AVERAGE CPM")
+      .should("not.contain.text", "BY AVERAGE ACCURACY")
+      .should("not.contain.text", "BY RACES PLAYED");
+  });
+});

--- a/packages/app/src/app/leaderboard/loaders.ts
+++ b/packages/app/src/app/leaderboard/loaders.ts
@@ -30,6 +30,21 @@ export async function getUsersWithResultCounts({
   });
 }
 
+export async function getAllUsersWithResults() {
+  return await prisma.user.findMany({
+    include: {
+      results: true,
+    },
+    where: {
+      achievements: {
+        some: {
+          achievementType: "FIFTH_RACE",
+        },
+      },
+    },
+  });
+}
+
 export async function getUsersWithResults({
   take,
   skip,

--- a/packages/app/src/app/leaderboard/page.tsx
+++ b/packages/app/src/app/leaderboard/page.tsx
@@ -64,11 +64,13 @@ export default async function LeaderboardPage({
 
   const user = await getCurrentUser();
   const allUsers = await getAllUsersWithResults();
+  const currUserIsRanked =
+    user !== undefined && allUsers.some((u) => u.id === user.id);
 
   return (
     <div className="pt-12">
       <Heading title="Leaderboard" description="Find your competition" />
-      {user !== undefined ? (
+      {currUserIsRanked ? (
         <UserRankings currentUser={user} allUsers={allUsers} />
       ) : null}
       <UsersTable data={users} pageCount={pageCount} />

--- a/packages/app/src/app/leaderboard/page.tsx
+++ b/packages/app/src/app/leaderboard/page.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-
-import { UsersTable } from "./users-table";
-import { User } from "@prisma/client";
 import { Heading } from "@/components/ui/heading";
+import { getCurrentUser } from "@/lib/session.js";
+import { User } from "@prisma/client";
 import {
+  getAllUsersWithResults,
   getTotalUsers,
   getUsersWithResultCounts,
   getUsersWithResults,
   isFieldInUser,
 } from "./loaders";
+import { UserRankings } from "./user-rankings";
+import { UsersTable } from "./users-table";
 
 export default async function LeaderboardPage({
   searchParams,
@@ -59,12 +60,17 @@ export default async function LeaderboardPage({
   }
 
   const totalUsers = await getTotalUsers();
-
   const pageCount = totalUsers === 0 ? 1 : Math.ceil(totalUsers / take);
+
+  const user = await getCurrentUser();
+  const allUsers = await getAllUsersWithResults();
 
   return (
     <div className="pt-12">
       <Heading title="Leaderboard" description="Find your competition" />
+      {user !== undefined ? (
+        <UserRankings currentUser={user} allUsers={allUsers} />
+      ) : null}
       <UsersTable data={users} pageCount={pageCount} />
     </div>
   );

--- a/packages/app/src/app/leaderboard/user-rankings.tsx
+++ b/packages/app/src/app/leaderboard/user-rankings.tsx
@@ -1,0 +1,114 @@
+import type { Result, User } from "@prisma/client";
+import { User as NextUser } from "next-auth";
+
+type UserWithResults = User & { results: Result[] };
+
+function convertNumberToOrdinal({ n }: { n: number }) {
+  // special case for 11, 12, 13
+  if (n % 100 === 11 || n % 100 === 12 || n % 100 === 13) {
+    return n + "th";
+  }
+
+  // standard ordinal rules
+  switch (n % 10) {
+    case 1:
+      return n + "st";
+    case 2:
+      return n + "nd";
+    case 3:
+      return n + "rd";
+    default:
+      return n + "th";
+  }
+}
+
+function getUserRankByValue({
+  userId,
+  values,
+}: {
+  userId: string;
+  values: { id: string; value: number }[];
+}) {
+  const rankMap = new Map();
+  let currentRank = 1;
+
+  values
+    .sort((a, b) => b.value - a.value)
+    .forEach((current, i, arr) => {
+      const next = arr[i + 1];
+
+      if (rankMap.has(current.id)) {
+        return;
+      }
+
+      rankMap.set(current.id, currentRank);
+
+      if (next === undefined || current.value === next.value) {
+        return;
+      }
+
+      currentRank++;
+    });
+
+  const userRank = rankMap.get(userId);
+  const userRankOrdinal = convertNumberToOrdinal({ n: userRank });
+  rankMap.delete(userId);
+
+  const sharesRank = [...rankMap.values()].some((r) => r === userRank);
+
+  if (sharesRank) {
+    return `T-${userRankOrdinal}`;
+  }
+
+  return userRankOrdinal;
+}
+
+function Ranking({ label, rank }: { label: string; rank: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="text-xs md:text-sm text-center text-muted-foreground uppercase">
+        {label}
+      </div>
+      <div className="text-2xl md:text-3xl">{rank}</div>
+    </div>
+  );
+}
+
+export async function UserRankings({
+  currentUser,
+  allUsers,
+}: {
+  currentUser: NextUser;
+  allUsers: UserWithResults[];
+}) {
+  const userRankByGamesPlayed = getUserRankByValue({
+    userId: currentUser.id,
+    values: allUsers.map((u) => ({ id: u.id, value: u.results.length })),
+  });
+
+  const userRankByAverageCPM = getUserRankByValue({
+    userId: currentUser.id,
+    values: allUsers.map((u) => ({ id: u.id, value: Number(u.averageCpm) })),
+  });
+
+  const userRankByAverageAcc = getUserRankByValue({
+    userId: currentUser.id,
+    values: allUsers.map((u) => ({
+      id: u.id,
+      value: Number(u.averageAccuracy),
+    })),
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-5 mt-2 p-2">
+      <h1 className="text-1xl md:text-2xl font-special font-bold tracking-tight text-primary">
+        Your Rankings
+      </h1>
+      <div className="w-full flex justify-evenly">
+        <Ranking label="by average cpm" rank={userRankByAverageCPM} />
+        <Ranking label="by average accuracy" rank={userRankByAverageAcc} />
+        <Ranking label="by races played" rank={userRankByGamesPlayed} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
---
[475]: Display Current User's Overall Rankings on Leaderboard Page
---

Display to the current user their ranking based upon average cpm, average accuracy, and total races played on leader board page.

Discord Username: @stevanfreeborn

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

+ add `getAllUsersWithResults` method to `loaders.ts` to get all
  users with their results from the database
+ add call to `getAllUsersWithResults` method in leaderboard page
+ add call to `getCurrentUser` method in leaderboard page
+ add `user-rankings.tsx` component to display the current users
  rankings based upon average cpm, average accuracy, and total
  games played
  + added logic to deal with players having same rank and reflecting
    that by appending `T-` to rank
  + display rank in ordinal format
+ add test to verify ranking doesn't display if user is not signed in.

## Related Tickets & Documents

- Related Issue #475 
- Closes #475 

## QA Instructions, Screenshots, Recordings

Browsers Tested:
+ Edge
+ Chrome
+ Firefox
+ Safari

UI Change Example:
![your_rankings_example](https://github.com/webdevcody/code-racer/assets/65925598/477355eb-388b-4731-8cc4-457d5ac6d30f)

### UI accessibility concerns?

I don't believe these changes impact the pages accessibility.

## Added/updated tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

No

## [optional] What gif best describes this PR or how it makes you feel?

![michael-scott-celebrate](https://github.com/webdevcody/code-racer/assets/65925598/013ccb9c-83be-4207-889a-ed75d89ffb9f)

