### PR TITLE
#548 Tabs not recognized in practice tests

### DIFF
--- a/packages/app/src/app/race/_components/race/race-practice.tsx
+++ b/packages/app/src/app/race/_components/race/race-practice.tsx
@@ -223,6 +223,10 @@ export default function RacePractice({
         indent += " ";
         i++;
       }
+      while (nextLine.charAt(i) === "\t") {
+        indent += "\t";
+        i++;
+      }
       setInput(input + "\n" + indent);
       setTextIndicatorPosition((prevTextIndicatorPosition) => {
         return prevTextIndicatorPosition + 1 + indent.length;
@@ -235,7 +239,7 @@ export default function RacePractice({
       setTotalErrors((prevTotalErrors) => prevTotalErrors + 1);
     }
 
-    if (e.key === code[input.length] && errors.length === 0 && e.key !== " ") {
+    if (e.key === code[input.length] && errors.length === 0 && e.key !== " " && e.key !== "\t") {
       const currTime = Date.now();
       const timeTaken = startTime ? (currTime - startTime.getTime()) / 1000 : 0;
       setRaceTimeStamp((prev) => [


### PR DESCRIPTION
---
title: Issue #548 | Tabs not recognized in practice tests
---

Discord Username: @writeonlycode

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Replicated the logic to deal with whitespaces at the beginning of a line in `packages/app/src/app/race/_components/race/race-practice.tsx`, so it can also deal with \t at the beginning of a line.

## Related Tickets & Documents

- Related Issue #548
- Closes #548

## QA Instructions, Screenshots, Recordings

1. Run a local instance of the App.
2. Click "Add Snippet"
3. Copy the code below & paste in the snippet to be added, & add the snippet:

```c++
#include <iostream>

int main() {
	std::cout << "Hello World!";
	return 0;
}
```

The code above has tab characters in it, so the snippet will be added with tab characters to the database.

4. Click "Race", select "C++" and run. You should see the new code snippet. If not, refresh until you got the correct snippet.
5. Before, when you reach the tab character, pressing tab does nothing and you are stuck. Now, the interface skips the tabs characters in the same way it skips whitespaces.

### UI accessibility concerns?

No accessibility concerns.

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
