### PR TITLE
fix: add missing parentheses to preventDefault

### DIFF
--- a/packages/app/src/app/race/_components/race/race-practice.tsx
+++ b/packages/app/src/app/race/_components/race/race-practice.tsx
@@ -112,7 +112,7 @@ export default function RacePractice({ user, snippet }: RacePracticeProps) {
     }
     // Reload Control + r
     if (e.ctrlKey && e.key === "r") {
-      e.preventDefault;
+      e.preventDefault();
       return;
     }
     // Catch Alt Gr - Please confirm I am unable to test this


### PR DESCRIPTION
---
title: Issue #NONE | [FIX]: add missing parentheses to preventDefault
---

Discord Username: @moaqz

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

The `ctrl + r` key combination wasn't working as expected because of missing parentheses on the e.preventDefault function.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
