### PR TITLE
[595] feat: add axis labels in race results

### DIFF
--- a/packages/app/src/app/result/chart.tsx
+++ b/packages/app/src/app/result/chart.tsx
@@ -199,9 +199,9 @@ function CurrentChart(props: CurrentChartProps) {
       <ResponsiveContainer height={300}>
         <LineChart data={raceTimeStamp} margin={{ right: 25, top: 10 }}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="char" tick={{ fontSize: 0 }} />
-          <YAxis yAxisId="left" />
-          <YAxis yAxisId="right" orientation="right" />
+          <XAxis dataKey="char" tick={{ fontSize: 0 }} label="Time" />
+          <YAxis yAxisId="left" label={{value: "Accuracy", angle: -90, dx: -14}} />
+          <YAxis yAxisId="right" orientation="right" label={{ value: "Cpm", offset: 30, angle: -90, dx: 20}} />
           <Line
             type="monotone"
             dataKey="accuracy"


### PR DESCRIPTION
---
[595] | Add labels to race results graph axes
---
Discord Username: @sourmans

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

- Added label to the <XAxis /> and <YAxis /> of race results graph
  Rationale: The X and Y axes were unlabeled and it was hard for the player to understand it

## Related Tickets & Documents

- Closes #595 

## QA Instructions, Screenshots, Recordings

1. Start a practice run and type to complete the snippet
2. Once the snippet completes the result graph will be presented with the axes labeled
3. Accuracy on the left Axes, Cpm on the right Axes, Time on the bottom axes

### UI accessibility concerns?

Accessibility is improved by this change since the axes are labeled

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
