### PR TITLE
Another potential fix for prettier plugin module not found problem

### DIFF
--- a/packages/app/src/config/prettier-plugin.d.ts
+++ b/packages/app/src/config/prettier-plugin.d.ts
@@ -1,0 +1,6 @@
+declare module "prettier-plugin-java" {
+  export { languages, parsers, printers, options, defaultOptions };
+}
+declare module "@prettier/plugin-ruby" {
+  export { languages, parsers, printers, options, defaultOptions };
+}

--- a/packages/app/src/config/site.ts
+++ b/packages/app/src/config/site.ts
@@ -1,6 +1,14 @@
+/* eslint-disable */
+/// <reference path="prettier-plugin.d.ts" />
+/* eslint-enable */
+
 import { type Options as PrettierOptions } from "prettier";
 import { type Language } from "./languages";
 export type SiteConfig = typeof siteConfig;
+
+import * as prettierPluginJava from "prettier-plugin-java";
+import * as prettierPluginGo from "prettier-plugin-go-template";
+import * as prettierPluginRuby from "@prettier/plugin-ruby";
 
 export const siteConfig = {
   name: "CodeRacer",

--- a/packages/app/src/config/site.ts
+++ b/packages/app/src/config/site.ts
@@ -85,9 +85,9 @@ export const siteConfig = {
         endOfLine: "lf",
         singleAttributePerLine: false,
         plugins: [
-          "prettier-plugin-java/dist/index.js",
-          "prettier-plugin-go-template/lib/index.js",
-          "@prettier/plugin-ruby/src/plugin.js",
+          "prettier-plugin-java",
+          "prettier-plugin-go-template",
+          "@prettier/plugin-ruby",
         ],
       } satisfies PrettierOptions,
       parserMap: new Map<Language, string>([


### PR DESCRIPTION
---
title: Issue # |
---

<!-- Please enusure your PR title follows the pattern:
[Issue ID] | Short description of the changes made
-->

Discord Username: @

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Another attempt at resolving module not found error on prod.
Since `prettier` module has explicitly imported by our codebase, and it's working fine, I'm thinking of explicitly import all prettier plugin module to force nextjs to resolve this module in build phase. This could potentially fix the problem.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

<!-- Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes. -->

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
