### PR TITLE
Fixed passing falsy value when timestamp diff is 0

### DIFF
--- a/packages/app/src/app/result/replay-timestamps.tsx
+++ b/packages/app/src/app/result/replay-timestamps.tsx
@@ -33,14 +33,18 @@ export const ReplayCode = ({ code }: TReplayCode) => {
 
     if (isPlaying && replayTimeStamp && currentIndex < replayTimeStamp.length) {
       const currentTimestamp = replayTimeStamp[currentIndex];
-      const nextTimestampDelay =
-        currentIndex + 1 < replayTimeStamp.length
-          ? replayTimeStamp[currentIndex + 1].time - currentTimestamp.time
-          : null;
+      let nextTimestampDelay = 0;
+
+      if (currentIndex + 1 < replayTimeStamp.length) {
+        nextTimestampDelay =
+          replayTimeStamp[currentIndex + 1].time - currentTimestamp.time;
+      } else {
+        return;
+      }
 
       timeout = setTimeout(() => {
         setCurrentIndex(currentIndex + 1);
-      }, nextTimestampDelay || currentTimestamp.time);
+      }, nextTimestampDelay);
     }
 
     return () => clearTimeout(timeout);


### PR DESCRIPTION
---
title: Issue #700 Fixed passing falsy value when timestamp diff is 0
---
Discord Username: @jwtly10

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ✅] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

I noticed that for me when I was practising, the replay functionality was not working. I believe this is because when I was typing fast, and the time difference between 2 key were essentially the same time, diff was calculated as 0. In the setTimeout there was a boolean check between this 0 || and the current epoch time. I believe this results in the timer duration being set to the epoch time (1439843984 etc) So the timer never ran and the replay function did not play. 

It is now working as expected, before and after shown below.

## Related Tickets & Documents

- Related Issue https://github.com/webdevcody/code-racer/issues/700
- Closes https://github.com/webdevcody/code-racer/issues/700

## QA Instructions, Screenshots, Recordings

Here is a video of my change, and the behaviour on the live app:

https://github.com/webdevcody/code-racer/assets/39057715/88b60751-4aae-4d9b-81e6-9fda60f83491

To test, you can perform a practise race and try to replay

### UI accessibility concerns?
NA


## Added/updated tests?

- [ ] 👍 yes
- [ ✅] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help