### PR TITLE
fixed the terms page as it wasn't viewing anything

### DIFF
--- a/packages/app/src/app/terms/page.tsx
+++ b/packages/app/src/app/terms/page.tsx
@@ -4,10 +4,8 @@ const page = () => {
     <>
       <Heading title="Terms" />
     <div>
-      <h1>CodeRacer - Terms of Service</h1>
-      <p><strong>Effective Date:</strong> [Date]</p>
-      
-      <p>Welcome to CodeRacer! These Terms of Service ("Terms") constitute a legal agreement between you and CodeRacer. Please read these Terms carefully before using our platform, which is accessible at <a href="https://code-racer-eight.vercel.app/">https://code-racer-eight.vercel.app/</a>. By using CodeRacer, you agree to be bound by these Terms.</p>
+      <h1>CodeRacer - Terms of Service</h1>      
+      <p>Welcome to CodeRacer! These Terms of Service Terms constitute a legal agreement between you and CodeRacer. Please read these Terms carefully before using our platform, which is accessible at <a href="https://code-racer-eight.vercel.app/">https://code-racer-eight.vercel.app/</a>. By using CodeRacer, you agree to be bound by these Terms.</p>
       
       <h2>1. User Accounts</h2>
       <p>
@@ -45,7 +43,7 @@ const page = () => {
 
       <h2>6. Limitation of Liability</h2>
       <p>
-        <strong>6.1. Disclaimer:</strong> CodeRacer is provided "as is," and we make no warranties or representations about the accuracy or reliability of the platform. Your use of CodeRacer is at your own risk.
+        <strong>6.1. Disclaimer:</strong> CodeRacer is provided as is, and we make no warranties or representations about the accuracy or reliability of the platform. Your use of CodeRacer is at your own risk.
       </p>
 
       <h2>7. Changes to Terms</h2>
@@ -58,6 +56,7 @@ const page = () => {
         <strong>8.1. Questions:</strong> If you have any questions or concerns about these Terms, please contact us at <a href="mailto:contact@coderacer.com">contact@coderacer.com</a>.
       </p>
     </div>
+    </>
   );
 };
 


### PR DESCRIPTION
---
title: Issue #735 |
---
fixed the terms page to view terms as it wasn't viewing any terms previously 
Discord Username: @2dudu

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [Y ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
fixed the terms page to view terms as it wasn't viewing any terms to because of an unclosed react fragment i also had to remove all quotation marks because it caused a react-unescaped error when testing , also the date wasn't added so i removed it until i receive any further updates 



## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings
previously :
![image](https://github.com/webdevcody/code-racer/assets/98246917/e7c2fb28-02a3-46af-9f76-3b6f4c695e70)

now:
![image](https://github.com/webdevcody/code-racer/assets/98246917/03012ae2-fd97-4ea2-9de4-b15b33c71b9a)

### UI accessibility concerns?

<!-- If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. -->

## Added/updated tests?

- [ ] 👍 yes
- [Y ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
