### PR TITLE
Added Privacy policy page and styled it according to website

### DIFF
--- a/packages/app/src/app/privacy/page.tsx
+++ b/packages/app/src/app/privacy/page.tsx
@@ -8,6 +8,61 @@ function PrivacyPage({}) {
         description="Privacy policies for Code Racer"
       />
       {/* ADD PRIVACY POLICY */}
+      <section className="text-left mt-4 text-sm lg:text-md" >
+        <h2 className="text-xl font-semibold">Introduction</h2>
+        <p className="mt-2">  
+          Welcome to Code Racer. We are comitted to protecting your personal information and your right to Privacy.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Information We Collect</h2>
+        <p className="mt-2">
+          We collect personal information that you provide to us, such as name,
+          address, contact information, passwords and security data, and payment
+          information.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">How We Use Your Information</h2>
+        <p className="mt-2">
+          We use personal information collected via our services for a variety
+          of business purposes described below. We process your personal
+          information for these purposes with your consent, to comply with legal
+          obligations, and/or because we have a legitimate interest in doing so.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Sharing Your Information</h2>
+        <p className="mt-2">
+          We only share information with your consent, to comply with laws, to
+          provide you with services, to protect your rights, or to fulfill
+          business obligations.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Cookies and Tracking Technologies</h2>
+        <p className="mt-2">
+          We may use cookies and similar tracking technologies to access or
+          store information. Specific information about how we use such
+          technologies and how you can refuse certain cookies is set out in our
+          Cookie Policy.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Your Privacy Rights</h2>
+        <p className="mt-2">
+          In some regions, you have rights that allow you greater access to and
+          control over your personal information. You may review, change, or
+          terminate your account at any time.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Data Security</h2>
+        <p className="mt-2">
+          We aim to protect your personal information through a system of
+          organizational and technical security measures.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-4">Contact Us</h2>
+        <p className="mt-2">
+          If you have questions or comments about this policy, you may email us
+          at support@coderacer.com.
+        </p>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
---
title: Issue #763  [Add to privacy and terms pages]
---

<!-- Please enusure your PR title follows the pattern:
[#763 ] |  In the app/privacy/page.tsx added the privacy policies and styled it using tailwind css according to the website,also made the page responsive to different devices.
-->

Discord Username: @haricharan61108

## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor 
- [ ] 📝 Documentation Update

## Description

This PR adds a new privacy policy page that follows accessibility guidelines, ensuring screen reader compatibility and sufficient color contrast. The page includes information about data collection, usage, and user rights.

##Below is the screenshot of the Privacy Page
![Privacy-Page](https://github.com/user-attachments/assets/b79e065d-1b4a-48a0-b217-0c5be94d470c)


##Steps to test this
1. Navigate to 'app/privacy/page.tsx' to view the new page.
2. Ensure the design matches with About or Terms page.
3. Test it on multiple browsers and devices.


## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

