### PR TITLE
Added content to the Privacy page

### DIFF
--- a/packages/app/src/app/privacy/page.tsx
+++ b/packages/app/src/app/privacy/page.tsx
@@ -7,9 +7,31 @@ function PrivacyPage({}) {
         title="Privacy Policies"
         description="Privacy policies for Code Racer"
       />
-      {/* ADD PRIVACY POLICY */}
+       <div className="mt-8 space-y-4">
+        <p>
+          At Code Racer, we are committed to protecting your privacy. This
+          document explains how we handle your data.
+        </p>
+        <ul className="list-disc list-inside">
+          <li>
+            <strong>Data Collection:</strong> We collect user data such as names,
+            email addresses, and activity logs to enhance the user experience.
+          </li>
+          <li>
+            <strong>Data Usage:</strong> Your data is used for improving
+            features, analytics, and delivering a personalized experience.
+          </li>
+          <li>
+            <strong>Third-Party Sharing:</strong> We do not share your data with
+            third parties without your consent.
+          </li>
+        </ul>
+        <p>
+          If you have any concerns, contact us at privacy@coderacer.com.
+        </p>
+      </div>
     </div>
   );
 }
-
 export default PrivacyPage;
+


### PR DESCRIPTION
---
title: "[#763] | Add content to Privacy and Terms pages"
---

Discord Username : hend#hend5500

## What type of PR is this? 

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [x] 📝 Documentation Update

## Description

Added additional content to the Privacy and Terms of Use pages, including detailed information on data collection, usage, and sharing policies.

## Related Tickets & Documents

- Problème #763
- Closes #763

## QA Instructions, Screenshots, Recordings

- Verify that the new content on the Privacy page is correctly displayed and readable.
- Ensure that the sections added are clearly separated and well-structured.
- Check that the new content aligns with the rest of the information on the website.


### UI accessibility concerns?
- No specific accessibility concerns, as only textual content was added.


## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

