### PR TITLE
[769] feat: enforce consent prompt in GitHub provider

### DIFF
--- a/packages/app/src/app/api/auth/[...nextauth]/route.ts
+++ b/packages/app/src/app/api/auth/[...nextauth]/route.ts
@@ -25,6 +25,9 @@ export const nextAuthOptions = {
     GithubProvider({
       clientId: env.GITHUB_CLIENT_ID,
       clientSecret: env.GITHUB_CLIENT_SECRET,
+      authorization:{
+        params: { prompt: "consent" },
+      }
     }),
   ],
   callbacks: {


### PR DESCRIPTION
**title: Issue #769 | Enforce consent prompt in GitHub provider**

Discord Username: @

**## What type of PR is this? (select all that apply)**

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

**## Description**

This PR updates the GitHub provider configuration by adding the prompt: "consent" parameter. With this change, users will now always see the authorization consent screen when they log in, even if they recently logged out. This fixes the issue where users were being automatically logged in without going through the authorization step again.
![image](https://github.com/user-attachments/assets/56049167-e581-4c6e-8320-c5ac8ace62e7)

**## Related Tickets & Documents**

- Related Issue: #769 
- Closes #769 

**## QA Instructions, Screenshots, Recordings**

1. Log out from the app.
2. Log back in using the GitHub provider.
3. Verify that the authorization consent screen is displayed as expected.

**### UI accessibility concerns?**

N/A (No UI changes)

**## Added/updated tests?**

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

**## [optional] Are there any post-deployment tasks we need to perform?**

No additional tasks required.

**## [optional] What gif best describes this PR or how it makes you feel?**