### PR TITLE
version no longer needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   code-racer-db:
     image: postgres


### PR DESCRIPTION
---
title: [Issue] | Removed obsolete version field from docker-compose.yml
---

GitHub Username: marti99-lab

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Removed the `version: "3.9"` line from `docker-compose.yml` since Docker Compose v2.0 and later no longer require it. This update ensures compatibility with the latest Docker Compose versions and resolves warnings during setup.

## Related Tickets & Documents

- Related Issue: Issue
- Closes Issue

## QA Instructions, Screenshots, Recordings

Test the Docker Compose setup by running `docker-compose up` on your local environment. Ensure that the warning related to the `version` field is no longer present.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

