### PR TITLE
[feat] Added a better designed privacy page #781

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Open your browser and visit <http://localhost:3000> to see the application runni
 
 ## Working on New Features
 
+
 If you're new to Github and working with open source repositories, I made a video a while back which walks you through the process:
 [![How to make a pull request on an open source project](https://img.youtube.com/vi/8A4TsoXJOs8/0.jpg)](https://youtu.be/8A4TsoXJOs8)
 

--- a/packages/app/src/app/privacy/page.tsx
+++ b/packages/app/src/app/privacy/page.tsx
@@ -1,15 +1,54 @@
 import { Heading } from "@/components/ui/heading";
+import Link from "next/link";
 
-function PrivacyPage({}) {
+const page = () => {
   return (
-    <div className="pt-12 pb-12">
-      <Heading
-        title="Privacy Policies"
-        description="Privacy policies for Code Racer"
-      />
-      {/* ADD PRIVACY POLICY */}
+    <div className="pt-12 pb-12 md:w-3/4 w-full md:pl-12 ">
+      <Heading title="Privacy Policies" />
+      <p className="text-sm md:text-md text-gray-600 dark:text-gray-300 text-left">Privacy policies for Code Racer</p>
+      <p className="text-left mt-6 text-sm lg:text-md">
+        At Code Racer, we value your privacy and are committed to protecting your personal information. This Privacy Policy outlines how we collect, use, and protect any data you share while using our platform.
+      </p>
+
+        <div className="flex flex-col justify-center mt-8 gap-4">
+          <section>
+            <h2 className="text-lg md:text-xl font-semibold">Information We Collect</h2>
+          <p className="mb-4 text-sm md:text-md">
+            At Code Racer, we collect limited information to offer you a smooth, competitive, and personalized experience. When you register or sign in (optionally via services like GitHub), we may collect basic user data such as your name, email, and profile image.        
+          </p>
+          </section>
+
+          <section className="my-2">
+            <h2 className="text-lg md:text-xl font-semibold">How We Use Your Information</h2>
+          <p className="text-sm md:text-md">
+            All collected information is used solely to enhance your experience on Code Racer. We use it to manage races, maintain leaderboards, track progress, and occasionally communicate important updates.
+          </p>
+          </section>
+
+          <section className="my-2 ">
+            <h2 className="text-lg md:text-xl font-semibold">Cookies and Tracking</h2>
+            <p className="text-sm md:text-md">
+              Cookies may be used to remember your session, improve navigation, and gather usage analytics. You can disable cookies in your browser settings if you prefer, but please note that some features of the site might not function as intended.
+            </p>
+          </section>
+
+          <section className="my-2">
+            <h2 className="text-lg md:text-xl font-semibold">Data Security</h2>
+            <p className="text-sm md:text-md">
+              We implement industry-standard security measures to protect your data. However, no system is 100% secure, so we advise users to keep strong passwords and log out after sessions.
+            </p>
+          </section>
+          
+          <section className="my-2">
+            <h2 className="text-lg md:text-xl font-semibold">Third-Party Services</h2>
+            <p className="text-sm md:text-md">
+              If we integrate with third-party services (like GitHub OAuth), their respective privacy policies will apply. We encourage users to review those policies before use.
+            </p>
+          </section>
+          
+        </div>
     </div>
   );
-}
+};
 
-export default PrivacyPage;
+export default page;


### PR DESCRIPTION
---
title: Issue #781 
---


## [#781 ] | Added a better designed privacy page.



## What type of PR is this? (select all that apply)

- [ X ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

I have added the Privacy Policy page, without changing the responsiveness of the UI. Followed the text-sizes and formats thar are being used in the app.

## Related Tickets & Documents

- Related Issue #781 
- Closes #

## QA Instructions, Screenshots, Recordings
Before 
<img width="1911" height="807" alt="Screenshot 2025-07-15 231244" src="https://github.com/user-attachments/assets/8db283bd-f4a5-438d-bae1-0dfabd1e63d6" />

After 
<img width="1888" height="881" alt="Screenshot 2025-07-15 230523" src="https://github.com/user-attachments/assets/4e3d9401-537e-43b0-920e-b1e3fcdad70a" />
<img width="1901" height="876" alt="Screenshot 2025-07-15 230557" src="https://github.com/user-attachments/assets/627400a7-aa76-4086-a6c3-59d1ea67280c" />

## Tested on

- Desktop screen
- Mobile screen

## Added/updated tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help


