### PR TITLE
test for ensuring the contributors page loads with correct contribution

### DIFF
--- a/packages/app/cypress/e2e/tests/TestContributerPage.cy.js
+++ b/packages/app/cypress/e2e/tests/TestContributerPage.cy.js
@@ -65,3 +65,18 @@ it("can click on contributor card and click on any commit message and redirected
       });
   });
 });
+it.only("can ensure that the contributors page loads with contributor data", () => {
+  // Verify the contributors page loads and displays contributor cards
+  contributorsPage.contributorCard().should("have.length.greaterThan", 0);
+  
+  // Verify each contributor card has required elements
+  contributorsPage.contributorCard().first().within(() => {
+    contributorsPage.contributorName().should("be.visible"); // Contributor name text
+  });
+  
+  // Verify the page renders contributor statistics
+  cy.contains("Contributors and counting!").should("be.visible");
+  cy.get("[data-cy='contributor-card']").each(($card) => {
+    cy.wrap($card).find("[data-cy='contributor-name']").should("exist");
+  });
+});


### PR DESCRIPTION
---
title: [Issue #___] | Add Cypress test to validate contributors page data rendering
---

Discord Username: @TaiJim8x

## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [] 📝 Documentation Update

## Description

This PR adds a Cypress end-to-end test to validate that the Contributors page loads correctly and renders contributor data as expected.

Specifically, the test verifies:

- At least one contributor card is rendered on page load
- Each contributor card contains a visible contributor name
- The contributors statistics text ("Contributors and counting!") is displayed
- Each rendered contributor card contains a `[data-cy='contributor-name']` element

This ensures that contributor data is successfully fetched and displayed in the UI, and guards against regressions where contributor cards fail to render or required elements are missing.

No breaking changes or UI modifications were introduced — this PR strictly improves test coverage.

## Related Tickets & Documents

- Related Issue #___
- Closes #___

## QA Instructions, Screenshots, Recordings

1. Run the application locally.
2. Navigate to the Contributors page.
3. Run Cypress:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the contributors page to verify proper loading and rendering of contributor data, including validation of contributor cards and page content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->