### PR TITLE
[763] chore: remove unused multiplayer import

### DIFF
--- a/packages/app/src/app/race/(play)/multiplayer/page.tsx
+++ b/packages/app/src/app/race/(play)/multiplayer/page.tsx
@@ -1,7 +1,7 @@
 import { getCurrentUser } from "@/lib/session";
 import { redirect } from "next/navigation";
 
-import RaceMultiplayer from "../../_components/race/game-multiplayer";
+
 import { Language, isValidLanguage } from "@/config/languages";
 import RaceMultiplayerRoom from "./room";
 


### PR DESCRIPTION
Removed unused `RaceMultiplayer` import from the multiplayer page component.

This resolves the ESLint unused import warning and keeps the file cleaner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **No end-user visible changes**
  * Internal code maintenance performed on the multiplayer race page. All functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webdevcody/code-racer/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->